### PR TITLE
Think twice before giving feedback to this community!

### DIFF
--- a/Think twice before giving feedback to this community! - Copy - Copy (2) - Copy - Copy.txt
+++ b/Think twice before giving feedback to this community! - Copy - Copy (2) - Copy - Copy.txt
@@ -1,0 +1,20 @@
+(Since everyone keeps closing this, I am going to continue to post it until one thread remains visible for discussion, no need to censor)
+
+![](https://i.gyazo.com/364f1b11bc57924374d0a8c81df1eeab.png)
+
+Lead developer sent this message after a user was giving his honest feedback via this [reddit thread](https://www.reddit.com/r/gamedev/comments/7gmtxl/godot_30_beta_1_is_there_right_in_time_for_ludum/dqk9nel/).
+
+They also said (I kid you not) -- giving feedback is "**bullying**",  a "**professional whiner**", and "**ranting**". Reduz's passive aggressive tone and insulting behavior is rampant there.  I already terminated my patreon account because of this, and not saying you should either (FLOSS projects) are great, however, for the lead developer to act like this towards people giving feedback.. is not okay!
+
+Let me re-iterate, not saying that you should stop giving feedback, but I just want this message to be seen across github and reach as far as possible. Because this kind of communication and how the lead developer treats a regular Godot developer is not right at all. I've never seen this behavior from a FLOSS project lead developer.  It's a shame, because the guy giving feedback is just a random person anyway, and the way the project managers and lead developers took it so personally like it was an attack (when it wasn't), means the lead developers/contributors are possibly not viewing your issues with the right mindset.  
+
+Also, after reading the last paragraph from [this post by akien](https://www.reddit.com/r/gamedev/comments/7gmtxl/godot_30_beta_1_is_there_right_in_time_for_ludum/dqlqj2v/)
+> From here on, we will avoid responding to xxx's threads on the various Godot communities, and focus instead on the huge amount of constructive feedback and bug reports that we get from other users. This will likely overlap with some of the issues mentioned above, which will thus be fixed eventually, but we won't accept being bullied into working on them now when we have different priorities. Users are free to disagree with our priorities, but in the end the contributors are the ones making the call.
+
+He's saying they will now favor/prioritize issues based on the user reporting it, and not the issue itself. (Extreme prejudice), which will not be good for the project because the issue should be irrelevant to the user reporting it. Just because if a user who has a snotty attitude that is reporting a huge client crash error, doesn't mean that client crash error should not be taken lightly.
+
+
+
+He's also stating that anyone giving hard feedback is now "bullying" them. Which is not true whatsoever.
+
+Just wanting to post this to get the word out there, hopefully some things change. @reduz @akien-mga  This is just unbelievable :( 


### PR DESCRIPTION

(Since everyone keeps closing this, I am going to continue to post it until one thread remains visible for discussion, no need to censor)

![](https://i.gyazo.com/364f1b11bc57924374d0a8c81df1eeab.png)

Lead developer sent this message after a user was giving his honest feedback via this [reddit thread](https://www.reddit.com/r/gamedev/comments/7gmtxl/godot_30_beta_1_is_there_right_in_time_for_ludum/dqk9nel/).

They also said (I kid you not) -- giving feedback is "**bullying**",  a "**professional whiner**", and "**ranting**". Reduz's passive aggressive tone and insulting behavior is rampant there.  I already terminated my patreon account because of this, and not saying you should either (FLOSS projects) are great, however, for the lead developer to act like this towards people giving feedback.. is not okay!

Let me re-iterate, not saying that you should stop giving feedback, but I just want this message to be seen across github and reach as far as possible. Because this kind of communication and how the lead developer treats a regular Godot developer is not right at all. I've never seen this behavior from a FLOSS project lead developer.  It's a shame, because the guy giving feedback is just a random person anyway, and the way the project managers and lead developers took it so personally like it was an attack (when it wasn't), means the lead developers/contributors are possibly not viewing your issues with the right mindset.  

Also, after reading the last paragraph from [this post by akien](https://www.reddit.com/r/gamedev/comments/7gmtxl/godot_30_beta_1_is_there_right_in_time_for_ludum/dqlqj2v/)
> From here on, we will avoid responding to xxx's threads on the various Godot communities, and focus instead on the huge amount of constructive feedback and bug reports that we get from other users. This will likely overlap with some of the issues mentioned above, which will thus be fixed eventually, but we won't accept being bullied into working on them now when we have different priorities. Users are free to disagree with our priorities, but in the end the contributors are the ones making the call.

He's saying they will now favor/prioritize issues based on the user reporting it, and not the issue itself. (Extreme prejudice), which will not be good for the project because the issue should be irrelevant to the user reporting it. Just because if a user who has a snotty attitude that is reporting a huge client crash error, doesn't mean that client crash error should not be taken lightly.



He's also stating that anyone giving hard feedback is now "bullying" them. Which is not true whatsoever.

Just wanting to post this to get the word out there, hopefully some things change. @reduz @akien-mga  This is just unbelievable :( 